### PR TITLE
feat: rebuild PullOutDrawer as a draggable bottom sheet

### DIFF
--- a/src/app/globals.scss
+++ b/src/app/globals.scss
@@ -4,7 +4,6 @@
 
 :root {
     --size-map-small: 100px;
-    --size-tooltip: 50px;
     --size-map-large: 500px;
     --size-map-home:300px;
     --fraction-tooltip: 80%;
@@ -104,31 +103,8 @@
     border-radius: 12px;
     box-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15);
     border-top: none;
-    transition: all 1s ease-out;
+    transition: height 0.4s cubic-bezier(0.32, 0.72, 0, 1);
     background-color: var(--color-plog-neutral);
-
-    .opener {
-        position: absolute;
-        transform: translate(-50%, 0%);
-        top: -5px;
-        left: 50%;
-        background: var(--color-plog-neutral);
-        border-radius: 3px;
-        padding-top: 5px;
-        width: 30px;
-        height: 30px;
-        transition: all 1s ease-out;
-        opacity: 1;
-
-        &.home {
-            opacity: 0;
-        }
-
-        &.open {
-            width: 40px;
-            height: 40px;
-        }
-    }
 
     &.expanded {
         box-shadow: 0px -10px 10px 0px var(--color-plog-accent);
@@ -139,55 +115,49 @@
         box-shadow: none;
     }
 
+    .map-description {
+        height: 32px;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 12px;
+        overflow: hidden;
+        opacity: 1;
+        transition:
+            opacity 0.4s ease-out,
+            height 0.4s ease-out,
+            transform 0.4s ease-out;
+
+        .day,
+        .km {
+            font-size: 20px;
+            font-weight: bold;
+            white-space: nowrap;
+            color: var(--color-plog-normal);
+        }
+
+        // Closed state: tucked up behind the map, ready to slide down.
+        &.is-collapsed {
+            height: 0;
+            opacity: 0;
+            transform: translateY(-8px);
+        }
+
+        &.empty {
+            opacity: 0;
+        }
+    }
+
     .mapcontainer {
         position: relative;
         transition: all 1s ease-out;
 
-        .description {
-            position: absolute;
-            left: 0;
-            height: var(--size-map-small);
-            padding: '5px';
-            width: var(--fraction-tooltip);
-            bottom: 0;
-            pointer-events: none;
-            transition: all 1s ease-out;
-            opacity: 0.8;
-
-            .innerdescription {
-                position: absolute;
-                transform: translate(-50%, -50%);
-                left: 50%;
-                top: 50%;
-                font-size: 25px;
-                font-weight: bold;
-                white-space: nowrap;
-                transition: all 1s ease-out;
-                text-shadow: 1px 1px 4px var(--color-plog-neutral);
-            }
-        }
-
-        &.expanded:not(.home) {
-            .description {
-                height: var(--size-tooltip);
-                width: 100%;
-                bottom: -15px;
-            }
-
-            padding-bottom: var(--size-tooltip);
-        }
-
         &.expanded.home {
             height: calc(100vh - var(--min-home-height));
-            padding-bottom: 0px;
         }
 
         &:not(.expanded) {
             height: var(--size-map-small);
-        }
-
-        &.home .description {
-            opacity: 0;
         }
 
         &.expanded {
@@ -197,10 +167,6 @@
             .map {
                 margin-left: -50%;
             }
-
-            .description .innerdescription {
-                text-shadow: none;
-            }
         }
 
         .mapframe {
@@ -208,6 +174,45 @@
             height: 100%;
             overflow: hidden;
             border-radius: 8px;
+        }
+
+        .map-description-overlay {
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            padding-left: 12px;
+            pointer-events: none;
+            opacity: 1;
+            transition:
+                opacity 0.4s ease-out,
+                transform 0.4s ease-out;
+            background: linear-gradient(
+                to right,
+                var(--color-plog-neutral-8) 0%,
+                var(--color-plog-neutral-8) 40%,
+                transparent 85%
+            );
+
+            .map-description-text {
+                font-size: 24px;
+                font-weight: bold;
+                white-space: nowrap;
+                color: var(--color-plog-normal);
+            }
+
+            // Peek/open: fade out and drift down as the row takes over below.
+            &.is-hidden {
+                opacity: 0;
+                transform: translateY(12px);
+            }
+
+            &.empty {
+                opacity: 0;
+            }
         }
 
         .map {

--- a/src/components/PullOutDrawer.tsx
+++ b/src/components/PullOutDrawer.tsx
@@ -1,61 +1,192 @@
 'use client';
+import { useEffect, useRef } from 'react';
 
 import { useContext, useState } from 'react';
 import { BookPageIndex } from '@/util/BookPageIndex';
 import DaySlider from './DaySlider';
 import ControlledMap from './map/Map';
 import { BookContext } from './Main';
-import { ChevronLeftSharp } from '@mui/icons-material';
+
+type DrawerSnap = 'closed' | 'peek' | 'open';
+const SNAP_ORDER: DrawerSnap[] = ['closed', 'peek', 'open'];
+
+// Reserve room above the drawer for the page title/nav on short screens.
+const MIN_RESERVED_FOR_CONTENT = 120;
+const OPEN_FRACTION = 0.8;
+const PEEK_FRACTION = 0.4;
+const CLOSED_HEIGHT = 240;
+
+// Everything in the drawer that isn't the map: padding + drag handle row +
+// day/distance label row + slider (DaySlider is h-[100px]). Used to size the
+// map so it fills the remaining drawer height. Keep in sync with the markup
+// below and the .map-description height in globals.scss.
+const DRAWER_CHROME = 176;
+
+// How far a real drag has to move before it counts as a drag (vs a tap).
+const DRAG_THRESHOLD = 8;
+// Momentum window (ms) — release velocity is projected this far to decide
+// whether a flick should carry past the nearest snap point.
+const PROJECTION_MS = 120;
 
 export default function PullOutDrawer() {
     const { setDisplayed, displayed, entries } = useContext(BookContext)!;
-    const [isHovering, setHovering] = useState(false);
-    const [extended, setExtended] = useState(false);
+    const [snap, setSnap] = useState<DrawerSnap>('closed');
+
+    const drawerRef = useRef<HTMLDivElement>(null);
+    const dragStartY = useRef(0);
+    const dragStartHeight = useRef(0);
+    const lastY = useRef(0);
+    const lastT = useRef(0);
+    const velocity = useRef(0); // px/ms of height change; positive = opening
+    const didDrag = useRef(false);
+
+    const [viewportHeight, setViewportHeight] = useState(
+        typeof window !== 'undefined' ? window.innerHeight : 900,
+    );
+
+    useEffect(() => {
+        const onResize = () => setViewportHeight(window.innerHeight);
+        window.addEventListener('resize', onResize);
+        return () => window.removeEventListener('resize', onResize);
+    }, []);
+
+    const maxDrawerHeight = Math.max(
+        CLOSED_HEIGHT,
+        viewportHeight - MIN_RESERVED_FOR_CONTENT,
+    );
+
+    const snapHeights: Record<DrawerSnap, number> = {
+        closed: CLOSED_HEIGHT,
+        peek: Math.min(viewportHeight * PEEK_FRACTION, maxDrawerHeight),
+        open: Math.min(viewportHeight * OPEN_FRACTION, maxDrawerHeight),
+    };
 
     const isHome = displayed.equals(BookPageIndex.homepage(entries));
-    const isOpen = isHovering || isHome || extended;
 
-    const setHover = (entry: BookPageIndex | null) => {
-        if (entry === null) {
-            setHovering(false);
-        } else {
+    // The homepage always shows the full map; otherwise the drawer stays at
+    // whatever snap position the user dragged it to. Scrubbing the slider does
+    // NOT change the drawer height — it only updates the displayed entry.
+    const effectiveSnap: DrawerSnap = isHome ? 'open' : snap;
+    const isOpen = effectiveSnap !== 'closed';
+    const mapExpanded = effectiveSnap === 'open';
+
+    // Size the map to fill whatever height the drawer currently has.
+    const mapHeight = Math.max(100, snapHeights[effectiveSnap] - DRAWER_CHROME);
+
+    // Called as the slider is scrubbed. Updates which entry is shown (map
+    // center + overlay text) without touching the drawer's snap position.
+    const onScrub = (entry: BookPageIndex | null) => {
+        if (entry !== null) {
             setDisplayed(entry);
-            setHovering(true);
-            setExtended(false);
         }
     };
 
+    function nearestSnap(height: number): DrawerSnap {
+        return SNAP_ORDER.reduce((closest, candidate) =>
+            Math.abs(snapHeights[candidate] - height) <
+            Math.abs(snapHeights[closest] - height)
+                ? candidate
+                : closest,
+        );
+    }
+
+    function handleDragStart(e: React.PointerEvent) {
+        // The homepage drawer is fixed (always open, content-driven); dragging
+        // it would leave a stale imperative height that React won't reconcile.
+        if (isHome || !drawerRef.current) return;
+        dragStartY.current = e.clientY;
+        dragStartHeight.current =
+            drawerRef.current.getBoundingClientRect().height;
+        lastY.current = e.clientY;
+        lastT.current = performance.now();
+        velocity.current = 0;
+        didDrag.current = false;
+        drawerRef.current.style.transition = 'none';
+        document.addEventListener('pointermove', handleDragMove);
+        document.addEventListener('pointerup', handleDragEnd);
+    }
+
+    function handleDragMove(e: PointerEvent) {
+        if (!drawerRef.current) return;
+
+        const now = performance.now();
+        const dt = now - lastT.current;
+        if (dt > 0) {
+            // Positive = moving up = drawer growing.
+            velocity.current = (lastY.current - e.clientY) / dt;
+        }
+        lastY.current = e.clientY;
+        lastT.current = now;
+
+        const delta = dragStartY.current - e.clientY; // positive = dragging up
+        if (Math.abs(delta) > DRAG_THRESHOLD) didDrag.current = true;
+
+        const newHeight = Math.min(
+            maxDrawerHeight,
+            Math.max(CLOSED_HEIGHT * 0.6, dragStartHeight.current + delta),
+        );
+        drawerRef.current.style.height = `${newHeight}px`;
+    }
+
+    function handleDragEnd() {
+        if (!drawerRef.current) return;
+
+        document.removeEventListener('pointermove', handleDragMove);
+        document.removeEventListener('pointerup', handleDragEnd);
+
+        drawerRef.current.style.transition = '';
+
+        if (!didDrag.current) {
+            // A tap: let the height snap back to the effective position; the
+            // handle's onClick handles the closed <-> open toggle.
+            drawerRef.current.style.height = `${snapHeights[effectiveSnap]}px`;
+            return;
+        }
+
+        // Project the release point by its velocity so a flick can carry past
+        // the nearest snap point (Google-Maps style), then settle on whichever
+        // of closed/peek/open is closest to that projected height.
+        const height = drawerRef.current.getBoundingClientRect().height;
+        const projected = height + velocity.current * PROJECTION_MS;
+        const newSnap = nearestSnap(projected);
+
+        setSnap(newSnap);
+        drawerRef.current.style.height = `${snapHeights[newSnap]}px`;
+    }
+
+    function handleHandleClick() {
+        if (didDrag.current) return; // the pointerup that ended a drag
+        setSnap((prev) => (prev === 'closed' ? 'open' : 'closed'));
+    }
+
     return (
         <div
+            ref={drawerRef}
             className={
                 'drawer ' + (isOpen ? 'open' : '') + (isHome ? ' home' : '')
             }
+            onPointerDown={handleDragStart}
             style={{
                 zIndex: 1100,
+                // On the homepage the drawer is content-driven (the map uses its
+                // own CSS height); elsewhere the snap position fixes the height.
+                height: isHome ? undefined : snapHeights[effectiveSnap],
             }}
         >
             <div
-                className={
-                    'opener ' + (isHome ? 'home ' : '') + (isOpen ? 'open' : '')
-                }
-                style={{
-                    zIndex: 1500,
-                }}
-                onClick={() => setExtended(!extended)}
+                className="flex justify-center pt-1 pb-4 cursor-grab touch-none"
+                onClick={handleHandleClick}
             >
-                <ChevronLeftSharp
-                    style={{
-                        transform:
-                            'rotate(90deg) ' +
-                            (extended ? 'scale(-1,1)' : 'scale(1,1)'),
-                        transition: 'all 1s ease-out',
-                        height: '100%',
-                        width: '100%',
-                    }}
-                />
+                <div className="w-10 h-1 rounded-full bg-gray-300" />
             </div>
-            <ControlledMap expanded={isOpen} expand={() => setExtended(true)} />
-            <DaySlider activeValue={setHover} />
+
+            <ControlledMap
+                expanded={mapExpanded}
+                mapHeight={isHome ? undefined : mapHeight}
+                descriptionOverlay={effectiveSnap === 'closed'}
+                expand={() => setSnap('open')}
+            />
+            <DaySlider activeValue={onScrub} />
         </div>
     );
 }

--- a/src/components/map/Map.tsx
+++ b/src/components/map/Map.tsx
@@ -70,6 +70,8 @@ function newCenter(
 
 type MapProps = {
     expanded: boolean;
+    mapHeight?: number;
+    descriptionOverlay?: boolean;
     expand: () => void;
 };
 
@@ -83,7 +85,12 @@ type MapState = {
     center: Coordinates;
 };
 
-export default function ControlledMap({ expanded, expand }: MapProps) {
+export default function ControlledMap({
+    expanded,
+    mapHeight,
+    descriptionOverlay,
+    expand,
+}: MapProps) {
     const { entries, displayed, setDisplayed } = useContext(BookContext)!;
     const [size, setSize] = useState<Size>({ width: 450, height: 350 });
     const [container, setContainer] = useState<HTMLDivElement | null>(null);
@@ -105,9 +112,9 @@ export default function ControlledMap({ expanded, expand }: MapProps) {
     const { center, zoom } = newCenter(entries, displayed, size);
 
     const theEntry = displayed.getEntry();
-    const description = theEntry
-        ? theEntry.getDaysSinceStart() + 1 + '.Tag | ' + theEntry.km + 'km'
-        : '';
+    const dayLabel = theEntry ? theEntry.getDaysSinceStart() + 1 + '.Tag' : '';
+    const kmLabel = theEntry ? theEntry.km + 'km' : '';
+    const hasEntry = theEntry != null;
 
     return (
         <>
@@ -118,22 +125,15 @@ export default function ControlledMap({ expanded, expand }: MapProps) {
                     (expanded ? 'expanded ' : '') +
                     (isHome ? 'home ' : '')
                 }
+                style={
+                    mapHeight !== undefined ? { height: mapHeight } : undefined
+                }
                 onClick={() => {
                     if (!expanded) {
                         expand();
                     }
                 }}
             >
-                <div
-                    className="description"
-                    style={{
-                        zIndex: 999,
-                    }}
-                >
-                    <div className="h-full relative">
-                        <span className="innerdescription">{description}</span>
-                    </div>
-                </div>
                 <div className="mapframe">
                     <div className="map">
                         <Map
@@ -185,6 +185,27 @@ export default function ControlledMap({ expanded, expand }: MapProps) {
                         </Map>
                     </div>
                 </div>
+                <div
+                    className={
+                        'map-description-overlay' +
+                        (descriptionOverlay ? '' : ' is-hidden') +
+                        (hasEntry ? '' : ' empty')
+                    }
+                >
+                    <span className="map-description-text">
+                        {dayLabel} | {kmLabel}
+                    </span>
+                </div>
+            </div>
+            <div
+                className={
+                    'map-description' +
+                    (descriptionOverlay ? ' is-collapsed' : '') +
+                    (hasEntry ? '' : ' empty')
+                }
+            >
+                <span className="day">{dayLabel}</span>
+                <span className="km">{kmLabel}</span>
             </div>
         </>
     );


### PR DESCRIPTION
Replace the click-only chevron drawer with a Google-Maps-style bottom sheet that has three snap positions (closed/peek/open):

- Drag the handle to resize; release settles on the snap nearest to the velocity-projected release point, so a big/fast swipe can skip peek. Tapping the handle toggles closed<->open.
- Snap heights are viewport-relative (peek 40vh, open 80vh) and clamped so the page title/nav above the drawer is never fully occluded.
- The map fills the available drawer height in every state instead of a fixed 500px cap.
- Scrubbing the slider no longer forces the drawer open; it only updates the displayed entry, so the drawer stays at its current position.
- Day/distance readout: overlaid on the map (gradient scrim) when closed, and split day-left / km-right below the map when peek/open, with a fade+slide transition between the two instead of a hard swap.
- Homepage keeps its content-driven height; dragging is disabled there.